### PR TITLE
Admin language update & fixes for users seeing past rounds

### DIFF
--- a/trivia/templates/admin/round.html
+++ b/trivia/templates/admin/round.html
@@ -61,13 +61,13 @@
                                 <th>Answer Key</th>
                                 <th>{{a.team.name}} Answer</th>
                                 <th>Correct?</th>
-                                <th>Update Points</th>
+                                <th>Update Number Correct</th>
                             </tr>
                             <tr class="table-secondary">
                                 <td class="center">{{a.question.answer}}</td> 
                                 <td class="center">{{a.answer}}</td>
                                 <td class="center"><input type="checkbox" id="check{{a.question.question_num}}" name="a{{a.question.question_num}}_correct" {%if a.correct %}checked {%endif%}></td>
-                                <td class="center"><input type="text" name="a{{a.question.question_num}}" id="points{{a.question.question_num}}" value="{{a.points.normalize}}" size=2></td>
+                                <td class="center"><input type="text" name="a{{a.question.question_num}}" id="points{{a.question.question_num}}" value="{{a.points.normalize}}" size=2 onclick="this.select();"></td>
                             </tr>
                         {%endif%}
                     {%endfor%}

--- a/trivia/templates/admin/score.html
+++ b/trivia/templates/admin/score.html
@@ -41,7 +41,7 @@
                                 <th>Answer Key</th>
                                 <th>{{a.team.name}} Answer</th>
                                 <th>Correct?</th>
-                                <th>Points</th>
+                                <th>Number Correct</th>
                             </tr>
                             <tr class="table-secondary">
                                 <td class="center">{{a.question.answer}}</td> 

--- a/trivia/templates/game.html
+++ b/trivia/templates/game.html
@@ -38,7 +38,7 @@
 										<span class="badge badge-secondary badge-pill">Inactive</span>
 									{%endif %}
 								</li>
-								{%if round.active  or round.round_num <= request.session.answered %}
+								{%if round.active  or value|stringformat:round.round_num in team.rounds_answered %}
 									<li class="list-group-item"><b>Round Name: </b> {{round.round_name}}</li>
 									<li class="list-group-item"><a href="{%url 'round' game.password round.round_num %}"><button class="btn {%if round.active %} btn-primary {%else %} btn-outline-primary {%endif%}btn-block">View</button></a></li>
 								{%endif%}

--- a/trivia/views.py
+++ b/trivia/views.py
@@ -457,7 +457,7 @@ def delete_team(request, game_id):
     Team.objects.get(pk=request.GET['team_id']).delete()
     context = {"teams": teams, 'game':game, 'alert':"Team deleted successfully"}
 
-    return render(request, "admin/view_teams.html", context)
+    return HttpResponseRedirect(reverse('admin_view_teams', args=(game.password,)))
 
 @login_required
 @permission_required('is_superuser')


### PR DESCRIPTION
Fixes include:

1) Admin scores now say "Number Correct" instead of "Points" to avoid confusion
2) Deleting Team does a redirect to view teams instead of re-rendering the page (Admin)
3) Users can now see past rounds that were submitted previously
4) Updating scores now highlights the whole cell for "Number Correct" for ease of updating new score values.

Fixes #45